### PR TITLE
Add URL to demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This is a bookmark site for personal NPM favorites, built with [Gatsby](https://
 
 It features search and tags to filter available packages – these are fetched from the [npms.io](https://npms.io/) API.
 
+## Demo
+
+https://npm-bookmarks.netlify.com
+
 ## Manage favorites
 
 Packages are added to `src/packages.json` including assigned tags.


### PR DESCRIPTION
Since the demo Url is also in Gatsby showcase you can put it also into the repo readme